### PR TITLE
Fix return of `html.fragments_fromstring`

### DIFF
--- a/lxml-stubs/html/_parse.pyi
+++ b/lxml-stubs/html/_parse.pyi
@@ -123,7 +123,7 @@ def document_fromstring(
     base_url: str | None = ...,
 ) -> HtmlElement: ...
 @overload
-def fragments_fromstring(
+def fragments_fromstring(  # type: ignore[overload-overlap]
     html: _AnyStr,
     no_leading_text: Literal[True],
     base_url: str | None = ...,
@@ -133,7 +133,7 @@ def fragments_fromstring(
 @overload
 def fragments_fromstring(
     html: _AnyStr,
-    no_leading_text: Literal[False] = ...,
+    no_leading_text: bool = ...,
     base_url: str | None = ...,
     parser: _HtmlElemParser | None = ...,
     **kw: Unused,

--- a/lxml-stubs/html/_parse.pyi
+++ b/lxml-stubs/html/_parse.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Iterable, MutableMapping
+from typing import Any, Iterable, Literal, MutableMapping, overload
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -122,13 +122,22 @@ def document_fromstring(
     *,
     base_url: str | None = ...,
 ) -> HtmlElement: ...
+@overload
 def fragments_fromstring(
     html: _AnyStr,
-    no_leading_text: bool = ...,
+    no_leading_text: Literal[True],
     base_url: str | None = ...,
     parser: _HtmlElemParser | None = ...,
     **kw: Unused,
 ) -> list[HtmlElement]: ...
+@overload
+def fragments_fromstring(
+    html: _AnyStr,
+    no_leading_text: Literal[False] = ...,
+    base_url: str | None = ...,
+    parser: _HtmlElemParser | None = ...,
+    **kw: Unused,
+) -> list[str | HtmlElement]: ...
 def fragment_fromstring(
     html: _AnyStr,
     create_parent: bool = ...,


### PR DESCRIPTION
If the string contains leading text, the first element of the returned list will be a `str`. Only if `no_leading_text=True` was specified can we guarantee that there will be no `str` fragment at the beginning.

Related documentation: https://lxml.de/apidoc/lxml.html.html#lxml.html.fragments_fromstring