### PR TITLE
fix: Accept a single tag= selector in iterators

### DIFF
--- a/lxml-stubs/etree/_element.pyi
+++ b/lxml-stubs/etree/_element.pyi
@@ -106,19 +106,22 @@ class _Element:
     ) -> Iterator[Self]: ...
     @overload
     def itersiblings(
-        self, *, tag: Iterable[_t._TagSelector] | None = None, preceding: bool = False
+        self,
+        *,
+        tag: _t._TagSelector | Iterable[_t._TagSelector] | None = None,
+        preceding: bool = False,
     ) -> Iterator[Self]: ...
     @overload
     def iterancestors(self, *tags: _t._TagSelector) -> Iterator[Self]: ...
     @overload
     def iterancestors(
-        self, *, tag: Iterable[_t._TagSelector] | None = None
+        self, *, tag: _t._TagSelector | Iterable[_t._TagSelector] | None = None
     ) -> Iterator[Self]: ...
     @overload
     def iterdescendants(self, *tags: _t._TagSelector) -> Iterator[Self]: ...
     @overload
     def iterdescendants(
-        self, *, tag: Iterable[_t._TagSelector] | None = None
+        self, *, tag: _t._TagSelector | Iterable[_t._TagSelector] | None = None
     ) -> Iterator[Self]: ...
     @overload
     def iterchildren(
@@ -126,13 +129,16 @@ class _Element:
     ) -> Iterator[Self]: ...
     @overload
     def iterchildren(
-        self, *, tag: Iterable[_t._TagSelector] | None = None, reversed: bool = False
+        self,
+        *,
+        tag: _t._TagSelector | Iterable[_t._TagSelector] | None = None,
+        reversed: bool = False,
     ) -> Iterator[Self]: ...
     @overload
     def iter(self, *tags: _t._TagSelector) -> Iterator[Self]: ...
     @overload
     def iter(
-        self, *, tag: Iterable[_t._TagSelector] | None = None
+        self, *, tag: _t._TagSelector | Iterable[_t._TagSelector] | None = None
     ) -> Iterator[Self]: ...
     @overload
     def itertext(
@@ -140,7 +146,10 @@ class _Element:
     ) -> Iterator[str]: ...
     @overload
     def itertext(
-        self, *, tag: Iterable[_t._TagSelector] | None = None, with_tail: bool = True
+        self,
+        *,
+        tag: _t._TagSelector | Iterable[_t._TagSelector] | None = None,
+        with_tail: bool = True,
     ) -> Iterator[str]: ...
     def makeelement(
         self,

--- a/lxml-stubs/html/_element.pyi
+++ b/lxml-stubs/html/_element.pyi
@@ -148,19 +148,22 @@ class HtmlElement(etree.ElementBase):
     ) -> Iterator[HtmlElement]: ...
     @overload
     def itersiblings(
-        self, *, tag: Iterable[_TagSelector] | None = None, preceding: bool = False
+        self,
+        *,
+        tag: _TagSelector | Iterable[_TagSelector] | None = None,
+        preceding: bool = False,
     ) -> Iterator[HtmlElement]: ...
     @overload
     def iterancestors(self, *tags: _TagSelector) -> Iterator[HtmlElement]: ...
     @overload
     def iterancestors(
-        self, *, tag: Iterable[_TagSelector] | None = None
+        self, *, tag: _TagSelector | Iterable[_TagSelector] | None = None
     ) -> Iterator[HtmlElement]: ...
     @overload
     def iterdescendants(self, *tags: _TagSelector) -> Iterator[HtmlElement]: ...
     @overload
     def iterdescendants(
-        self, *, tag: Iterable[_TagSelector] | None = None
+        self, *, tag: _TagSelector | Iterable[_TagSelector] | None = None
     ) -> Iterator[HtmlElement]: ...
     @overload
     def iterchildren(
@@ -168,13 +171,16 @@ class HtmlElement(etree.ElementBase):
     ) -> Iterator[HtmlElement]: ...
     @overload
     def iterchildren(
-        self, *, tag: Iterable[_TagSelector] | None = None, reversed: bool = False
+        self,
+        *,
+        tag: _TagSelector | Iterable[_TagSelector] | None = None,
+        reversed: bool = False,
     ) -> Iterator[HtmlElement]: ...
     @overload
     def iter(self, *tags: _TagSelector) -> Iterator[HtmlElement]: ...
     @overload
     def iter(
-        self, *, tag: Iterable[_TagSelector] | None = None
+        self, *, tag: _TagSelector | Iterable[_TagSelector] | None = None
     ) -> Iterator[HtmlElement]: ...
     @overload
     def itertext(
@@ -182,7 +188,10 @@ class HtmlElement(etree.ElementBase):
     ) -> Iterator[str]: ...
     @overload
     def itertext(
-        self, *, tag: Iterable[_TagSelector] | None = None, with_tail: bool = True
+        self,
+        *,
+        tag: _TagSelector | Iterable[_TagSelector] | None = None,
+        with_tail: bool = True,
     ) -> Iterator[str]: ...
     def makeelement(
         self,


### PR DESCRIPTION
As the name of the argument implies, the value of a "tag" can be a single selector: https://github.com/lxml/lxml/blob/a9f31d9ba0f6db7b0c6576b4b9014a4ea7649eca/src/lxml/etree.pyx#L1505-L1513