### PR TITLE
lxml.html.fragment_fromstring create_parent argument can be string

### DIFF
--- a/src/lxml-stubs/html/_parse.pyi
+++ b/src/lxml-stubs/html/_parse.pyi
@@ -99,7 +99,7 @@ def fragments_fromstring(
 ) -> list[str | HtmlElement]: ...
 def fragment_fromstring(
     html: str | bytes,
-    create_parent: bool = False,
+    create_parent: bool | str = False,
     base_url: str | None = None,
     parser: _HtmlElemParser | None = None,
 ) -> HtmlElement: ...


### PR DESCRIPTION
lxml.html.fragment_fromstring's create_parent argument can be a string to specify a tag name.