### PR TITLE
Replace factory functions with classes. Second try.

### DIFF
--- a/src/lxml-stubs/_types.pyi
+++ b/src/lxml-stubs/_types.pyi
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Callable,
     Collection,
-    Generic,
     Iterable,
     Literal,
     Mapping,
@@ -156,31 +155,6 @@ _SaxEventNames = Literal[
 
 _ET = TypeVar("_ET", bound=_Element, default=_Element)
 _ET_co = TypeVar("_ET_co", bound=_Element, default=_Element, covariant=True)
-
-class _ElementFactory(Protocol, Generic[_ET_co]):
-    """Element factory protocol
-
-    This is callback protocol for `makeelement()` method of
-    various element objects, with following signature (which
-    is identical to `etree.Element()` factory):
-
-    ```python
-    (_tag, attrib=..., nsmap=..., **_extra)
-    ```
-
-    The mapping in `attrib` argument and all `_extra` keyword
-    arguments would be merged together, with `_extra` taking
-    precedence over `attrib`.
-    """
-
-    def __call__(
-        self,
-        _tag: _TagName,
-        /,
-        attrib: _AttrMapping | None = None,
-        nsmap: _NSMapArg | None = None,
-        **_extra: _AttrVal,
-    ) -> _ET_co: ...
 
 # HACK _TagSelector filters element type not by classes, but checks for exact
 # element *factory functions* instead (etree.Element() and friends). Python

--- a/src/lxml-stubs/builder.pyi
+++ b/src/lxml-stubs/builder.pyi
@@ -1,7 +1,6 @@
 from typing import Any, Callable, Generic, Mapping, Protocol, overload
 
 from ._types import (
-    _ElementFactory,
     _ET_co,
     _NSMapArg,
     _NSTuples,
@@ -58,7 +57,7 @@ class ElementMaker(Generic[_ET_co]):
         namespace: str | None = None,
         nsmap: _NSMapArg | _NSTuples | None = None,  # dict()
         *,
-        makeelement: _ElementFactory[_ET_co],
+        makeelement: type[_ET_co],
     ) -> ElementMaker[_ET_co]: ...
     @overload  # makeelement is positional
     def __new__(
@@ -66,7 +65,7 @@ class ElementMaker(Generic[_ET_co]):
         typemap: _TypeMapArg | None,
         namespace: str | None,
         nsmap: _NSMapArg | _NSTuples | None,
-        makeelement: _ElementFactory[_ET_co],
+        makeelement: type[_ET_co],
     ) -> ElementMaker[_ET_co]: ...
     @overload  # makeelement is default or absent
     def __new__(
@@ -104,7 +103,7 @@ class ElementMaker(Generic[_ET_co]):
     # invariance has posed some challenge to typing. We can afford
     # some more restriction as return value or attribute.
     @property
-    def _makeelement(self) -> _ElementFactory[_ET_co]: ...
+    def _makeelement(self) -> type[_ET_co]: ...
     @property
     def _namespace(self) -> str | None: ...
     @property
@@ -112,4 +111,4 @@ class ElementMaker(Generic[_ET_co]):
     @property
     def _typemap(self) -> dict[type[Any], Callable[[_ET_co, Any], None]]: ...
 
-E: ElementMaker
+E: ElementMaker[_Element]

--- a/src/lxml-stubs/etree/__init__.pyi
+++ b/src/lxml-stubs/etree/__init__.pyi
@@ -26,6 +26,8 @@ from ._dtd import (
     DTDValidateError as DTDValidateError,
 )
 from ._element import (
+    Element as Element,
+    ElementTree as ElementTree,
     _Attrib as _Attrib,
     _Comment as _Comment,
     _Element as _Element,
@@ -36,8 +38,6 @@ from ._element import (
 from ._factory_func import (
     PI as PI,
     Comment as Comment,
-    Element as Element,
-    ElementTree as ElementTree,
     Entity as Entity,
     ProcessingInstruction as ProcessingInstruction,
     SubElement as SubElement,

--- a/src/lxml-stubs/etree/_element.pyi
+++ b/src/lxml-stubs/etree/_element.pyi
@@ -7,6 +7,7 @@ from typing import (
     Iterator,
     Literal,
     Mapping,
+    TypeAlias,
     TypeVar,
     final,
     overload,
@@ -40,6 +41,16 @@ class _Element:
     --------
     - [API Documentation](https://lxml.de/apidoc/lxml.etree.html#lxml.etree._Element)
     """
+
+    def __init__(  # Args identical to Element.makeelement
+        self,
+        _tag: _t._TagName,
+        /,
+        attrib: _t._AttrMapping | None = ...,
+        nsmap: _t._NSMapArg | None = ...,
+        **_extra: _t._AttrVal,
+    ) -> None: ...
+
     #
     # Common properties
     #
@@ -557,7 +568,7 @@ class _Element:
         - [API Documentation](https://lxml.de/apidoc/lxml.etree.html#lxml.etree._Element.itertext)
         - [Possible tag values in `iter()`](https://lxml.de/apidoc/lxml.etree.html#lxml.etree._Element.iter)
         """
-    makeelement: _t._ElementFactory[Self]
+    makeelement: type[Self]
     """Creates a new element associated with the same document.
 
     See Also
@@ -663,6 +674,8 @@ class _Element:
         self, tag: _t._TagSelector | None = None, *tags: _t._TagSelector
     ) -> Iterator[Self]: ...
 
+Element: TypeAlias = _Element
+
 _ET2_co = TypeVar("_ET2_co", bound=_Element, default=_Element, covariant=True)
 
 # ET class notation is specialized, indicating the type of element
@@ -673,6 +686,26 @@ _ET2_co = TypeVar("_ET2_co", bound=_Element, default=_Element, covariant=True)
 # It is considered harmful to support such corner case, which
 # adds much complexity without any benefit.
 class _ElementTree(Generic[_t._ET_co]):
+
+    @overload  # from element, parser ignored
+    def __new__(cls, element: _t._ET_co) -> _ElementTree[_t._ET_co]: ...
+    @overload  # from file source, custom parser
+    def __new__(
+        cls,
+        element: None = ...,
+        *,
+        file: _t._FileReadSource,
+        parser: _t._DefEtreeParsers[_t._ET_co],
+    ) -> _ElementTree[_t._ET_co]: ...
+    @overload  # from file source, default parser
+    def __new__(
+        cls,
+        element: None = ...,
+        *,
+        file: _t._FileReadSource,
+        parser: None = ...,
+    ) -> _ElementTree: ...
+
     @property
     def parser(self) -> _t._DefEtreeParsers[_t._ET_co] | None: ...
     @property
@@ -943,6 +976,8 @@ class _ElementTree(Generic[_t._ET_co]):
         compression: int | None = 0,
         inclusive_ns_prefixes: Iterable[str | bytes] | None = None,
     ) -> None: ...
+
+ElementTree: TypeAlias = _ElementTree
 
 # Behaves like MutableMapping but deviates a lot in details
 @final

--- a/src/lxml-stubs/etree/_factory_func.pyi
+++ b/src/lxml-stubs/etree/_factory_func.pyi
@@ -4,18 +4,13 @@ from .._types import (
     _ET,
     _AttrMapping,
     _AttrVal,
-    _DefEtreeParsers,
-    _ElementFactory,
-    _ET_co,
-    _FileReadSource,
     _NSMapArg,
     _TagName,
     _TextArg,
 )
 from ..html import HtmlElement
 from ..objectify import ObjectifiedElement, StringElement
-from ._element import _Comment, _ElementTree, _Entity, _ProcessingInstruction
-from ._parser import CustomTargetParser
+from ._element import _Comment, _Entity, _ProcessingInstruction
 
 _T = TypeVar("_T")
 
@@ -27,8 +22,6 @@ def ProcessingInstruction(
 PI = ProcessingInstruction
 
 def Entity(name: _TextArg) -> _Entity: ...
-
-Element: _ElementFactory
 
 # SubElement is a bit more complex than expected, as it
 # handles other kinds of element, like HtmlElement
@@ -71,78 +64,3 @@ def SubElement(
     nsmap: _NSMapArg | None = None,
     **_extra: _AttrVal,
 ) -> _ET: ...
-@overload  # from element, parser ignored
-def ElementTree(
-    element: _ET,
-    *,
-    file: None = None,
-) -> _ElementTree[_ET]:
-    """ElementTree wrapper class for Element objects.
-
-    Annotation
-    ----------
-    This overload is used when creating an ElementTree directly from a root
-    Element object. Other arguments are ignored in this case.
-
-    See Also
-    --------
-    - [API Documentation](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.ElementTree)
-    """
-
-@overload  # from file source, standard parser
-def ElementTree(
-    element: None = None,
-    *,
-    file: _FileReadSource,
-    parser: _DefEtreeParsers[_ET_co],
-) -> _ElementTree[_ET_co]:
-    """ElementTree wrapper class for Element objects.
-
-    Annotation
-    ----------
-    This overload is used when creating an ElementTree from a file source with
-    user-supplied standard parser.
-
-    See Also
-    --------
-    - [API Documentation](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.ElementTree)
-    """
-
-@overload  # from file source, custom target parser
-def ElementTree(
-    element: None = None,
-    *,
-    file: _FileReadSource,
-    parser: CustomTargetParser[_T],
-) -> _T:
-    """ElementTree wrapper class for Element objects.
-
-    Annotation
-    ----------
-    This overload is used when creating an ElementTree from a file source with
-    custom target parser. Returns the result dictated by parser target object
-    instead of ElementTree.
-
-    See Also
-    --------
-    - [API Documentation](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.ElementTree)
-    """
-
-@overload  # from file source, no parser supplied
-def ElementTree(
-    element: None = None,
-    *,
-    file: _FileReadSource,
-    parser: None = None,
-) -> _ElementTree:
-    """ElementTree wrapper class for Element objects.
-
-    Annotation
-    ----------
-    This overload is used when creating an ElementTree from a file source
-    without a parser supplied. The default parser is used in this case.
-
-    See Also
-    --------
-    - [API Documentation](https://lxml.de/apidoc/lxml.etree.html#lxml.etree.ElementTree)
-    """

--- a/src/lxml-stubs/etree/_iterparse.pyi
+++ b/src/lxml-stubs/etree/_iterparse.pyi
@@ -3,7 +3,6 @@ from _typeshed import SupportsRead
 from typing import Iterable, Iterator, Literal, TypeVar, overload
 
 from .._types import (
-    _ElementFactory,
     _ElementOrTree,
     _ET_co,
     _FilePath,
@@ -181,7 +180,7 @@ class iterparse(Iterator[_T_co]):
         self,
         lookup: ElementClassLookup | None = None,
     ) -> None: ...
-    makeelement: _ElementFactory
+    makeelement: type[_T_co]
 
 class iterwalk(Iterator[_T_co]):
     """Tree walker that generates events from an existing tree as if it

--- a/src/lxml-stubs/etree/_parser.pyi
+++ b/src/lxml-stubs/etree/_parser.pyi
@@ -11,7 +11,6 @@ from typing import (
 
 from .._types import (
     _DefEtreeParsers,
-    _ElementFactory,
     _ET_co,
     _SaxEventNames,
     _TagSelector,
@@ -75,7 +74,7 @@ class CustomTargetParser(Generic[_T]):
         """The version of the underlying XML parser."""
     def copy(self) -> Self:
         """Create a new parser with the same configuration."""
-    makeelement: _ElementFactory[_Element]
+    makeelement: type[_Element]
     """Creates a new element associated with this parser."""
     @property
     def feed_error_log(self) -> _ListErrorLog:
@@ -185,7 +184,7 @@ class XMLParser(Generic[_ET_co]):
         """The version of the underlying XML parser."""
     def copy(self) -> Self:
         """Create a new parser with the same configuration."""
-    makeelement: _ElementFactory[_ET_co]
+    makeelement: type[_ET_co]
     """Creates a new element associated with this parser."""
     def set_element_class_lookup(
         self, lookup: ElementClassLookup | None = None
@@ -389,7 +388,7 @@ class HTMLParser(Generic[_ET_co]):
         """The version of the underlying XML parser."""
     def copy(self) -> Self:
         """Create a new parser with the same configuration."""
-    makeelement: _ElementFactory[_ET_co]
+    makeelement: type[_ET_co]
     """Creates a new element associated with this parser."""
     def set_element_class_lookup(
         self, lookup: ElementClassLookup | None = None

--- a/src/lxml-stubs/etree/_saxparser.pyi
+++ b/src/lxml-stubs/etree/_saxparser.pyi
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from typing import Callable, Protocol, TypeVar
 
-from .._types import _DefEtreeParsers, _ElementFactory
+from .._types import _DefEtreeParsers
 from ._element import _Comment, _Element, _ProcessingInstruction
 from ._parser import XMLSyntaxError
 
@@ -60,7 +60,7 @@ class TreeBuilder(ParserTarget[_Element]):
     def __init__(
         self,
         *,
-        element_factory: _ElementFactory[_Element] | None = None,
+        element_factory: type[_Element] | None = None,
         parser: _DefEtreeParsers | None = None,
         comment_factory: Callable[..., _Comment] | None = None,
         pi_factory: Callable[..., _ProcessingInstruction] | None = None,

--- a/src/lxml-stubs/html/_element.pyi
+++ b/src/lxml-stubs/html/_element.pyi
@@ -11,11 +11,13 @@ from typing import (
 
 from .. import etree
 from .._types import (
+    _AttrMapping,
     _AttrName,
     _AttrVal,
-    _ElementFactory,
     _ElemPathArg,
+    _NSMapArg,
     _StrOnlyNSMap,
+    _TagName,
     _TagSelector,
 )
 from ..cssselect import _CSSTransArg
@@ -264,7 +266,7 @@ class HtmlElement(etree.ElementBase):
         *,
         with_tail: bool = True,
     ) -> Iterator[str]: ...
-    makeelement: _ElementFactory[HtmlElement]  # pyright: ignore[reportIncompatibleVariableOverride]
+    makeelement: type[HtmlElement]  # pyright: ignore[reportIncompatibleVariableOverride]
     def find(
         self,
         path: _ElemPathArg,
@@ -331,4 +333,10 @@ class HtmlEntity(etree.EntityBase, HtmlElement): ...  # type: ignore[misc]  # py
 # Factory func, there is no counterpart for SubElement though
 # (use etree.SubElement())
 #
-Element: _ElementFactory[HtmlElement]
+def Element(
+        _tag: _TagName,
+        /,
+        attrib: _AttrMapping | None = None,
+        nsmap: _NSMapArg | None = None,
+        **_extra: _AttrVal,
+    ) -> HtmlElement: ...

--- a/src/lxml-stubs/html/soupparser.pyi
+++ b/src/lxml-stubs/html/soupparser.pyi
@@ -6,7 +6,7 @@ from bs4.builder import TreeBuilder
 from bs4.element import PageElement
 from bs4.filter import SoupStrainer
 
-from .._types import _ET, _ElementFactory, _FileReadSource
+from .._types import _ET, _FileReadSource
 from ..etree import _ElementTree
 from . import HtmlElement
 
@@ -70,7 +70,7 @@ def fromstring(
 def fromstring(
     data: str | bytes | IO[str] | IO[bytes],
     beautifulsoup: type[BeautifulSoup] | None,
-    makeelement: _ElementFactory[_ET],
+    makeelement: type[_ET],
     *,
     features: _Features | Collection[_Features] = "html.parser",
     builder: TreeBuilder | type[TreeBuilder] | None = None,
@@ -97,7 +97,7 @@ def fromstring(
     data: str | bytes | IO[str] | IO[bytes],
     beautifulsoup: type[BeautifulSoup] | None = None,
     *,
-    makeelement: _ElementFactory[_ET],
+    makeelement: type[_ET],
     features: _Features | Collection[_Features] = "html.parser",
     builder: TreeBuilder | type[TreeBuilder] | None = None,
     parse_only: SoupStrainer | None = None,
@@ -173,7 +173,7 @@ def parse(
 def parse(
     file: _FileReadSource,
     beautifulsoup: type[BeautifulSoup] | None,
-    makeelement: _ElementFactory[_ET],
+    makeelement: type[_ET],
     *,
     features: _Features | Collection[_Features] = "html.parser",
     builder: TreeBuilder | type[TreeBuilder] | None = None,
@@ -199,7 +199,7 @@ def parse(  # makeelement is kw
     file: _FileReadSource,
     beautifulsoup: type[BeautifulSoup] | None = None,
     *,
-    makeelement: _ElementFactory[_ET],
+    makeelement: type[_ET],
     features: _Features | Collection[_Features] = "html.parser",
     builder: TreeBuilder | type[TreeBuilder] | None = None,
     parse_only: SoupStrainer | None = None,
@@ -247,7 +247,7 @@ def parse(
 @overload
 def convert_tree(
     beautiful_soup_tree: BeautifulSoup,
-    makeelement: _ElementFactory[_ET],
+    makeelement: type[_ET],
 ) -> list[_ET]:
     """Convert a BeautifulSoup tree to a list of Element trees.
 

--- a/src/lxml-stubs/objectify/_factory.pyi
+++ b/src/lxml-stubs/objectify/_factory.pyi
@@ -8,7 +8,6 @@ from .._types import (
     _AttrMapping,
     _AttrTuples,
     _AttrVal,
-    _ElementFactory,
     _NSMapArg,
     _TagName,
 )
@@ -318,7 +317,7 @@ class ElementMaker:
         namespace: str | None = None,
         nsmap: _NSMapArg | None = None,
         annotate: bool = True,
-        makeelement: _ElementFactory[_e.ObjectifiedElement] | None = None,
+        makeelement: type[_e.ObjectifiedElement] | None = None,
     ) -> None: ...
     # Special notes:
     # - Attribute values supplied as children dict will be stringified,

--- a/src/lxml-stubs/sax.pyi
+++ b/src/lxml-stubs/sax.pyi
@@ -1,7 +1,7 @@
 from typing import Generic, overload
 from xml.sax.handler import ContentHandler
 
-from ._types import _ET, SupportsLaxItems, Unused, _ElementFactory, _ElementOrTree
+from ._types import _ET, SupportsLaxItems, Unused, _ElementOrTree
 from .etree import LxmlError, _ElementTree, _ProcessingInstruction
 
 class SaxError(LxmlError): ...
@@ -17,10 +17,10 @@ class ElementTreeContentHandler(Generic[_ET], ContentHandler):
     # Not adding _get_etree(), already available as public property
     @overload
     def __new__(
-        cls, makeelement: _ElementFactory[_ET]
+        cls, makeelement: type[_ET]
     ) -> ElementTreeContentHandler[_ET]: ...
     @overload
-    def __new__(cls, makeelement: None = None) -> ElementTreeContentHandler: ...
+    def __new__(cls, makeelement: None = None) -> ElementTreeContentHandler[_ET]: ...
     @property
     def etree(self) -> _ElementTree[_ET]: ...
 

--- a/tests/runtime/allowlist.txt
+++ b/tests/runtime/allowlist.txt
@@ -105,6 +105,16 @@ lxml\.objectify\.Element
 lxml\.objectify\.SubElement
 lxml\.objectify\.annotate
 
+# Cannot inspect elements of virtual subclasses
+lxml.etree.Element.*
+lxml.etree.ElementTree.*
+
+# Generic classes do not need explicit __class_getitem__
+lxml.builder.ElementMaker.__class_getitem__
+lxml.etree.HTMLParser.__class_getitem__
+lxml.etree.XMLParser.__class_getitem__
+lxml.sax.ElementTreeContentHandler.__class_getitem__
+
 # Cython class __init__ clobbered by generic signature
 lxml\.builder\.ElementMaker\.__init__
 lxml\.etree\.ETCompatXMLParser\.__init__

--- a/tests/static/test-annotations.yml
+++ b/tests/static/test-annotations.yml
@@ -1,5 +1,9 @@
 # Test functions with lxml type annotations.
-- case: annaotate_element
+# There are two copies of each test:
+# One with the private _Element and _ElementTree.
+# One with the public Element and ElementTree.
+
+- case: annaotate_element_private
   main: |
     from lxml import etree as e
 
@@ -11,7 +15,7 @@
         el = e.Element("test")
         view_element(el)
 
-- case: annaotate_tree
+- case: annaotate_tree_private
   main: |
     from lxml import etree as e
 
@@ -29,7 +33,7 @@
         tree = e.ElementTree(el)
         tree_root(tree)
 
-- case: annaotate_comment
+- case: annaotate_comment_private
   main: |
     from lxml import etree as e
 
@@ -50,7 +54,7 @@
     print(comm.tag == e.Comment)
     check_if_element_is_comment(comm)
 
-- case: annaotate_html
+- case: annaotate_html_private
   main: |
     from lxml import etree as e
     from lxml import html as h
@@ -62,4 +66,69 @@
         element_tree(et)
 
     def element_tree_not_html(et: e._ElementTree[e._Element]) -> None:
+        html_tree(et)  # E: Argument 1 to "html_tree" has incompatible type "_ElementTree[_Element]"; expected "_ElementTree[HtmlElement]"  [arg-type]
+
+- case: annaotate_element_public
+  main: |
+    from lxml import etree as e
+
+    def view_element(el: e.Element) -> None:
+        reveal_type(el)  # N: Revealed type is "lxml.etree._element._Element"
+        assert isinstance(e, e.Element)
+
+    def call_view_element() -> None:
+        el = e.Element("test")
+        view_element(el)
+
+- case: annaotate_tree_public
+  main: |
+    from lxml import etree as e
+
+    def tree_root(tree: e.ElementTree[e.Element]) -> None:
+        el = tree.getroot()
+        reveal_type(el)  # N: Revealed type is "lxml.etree._element._Element"
+
+    def tree_is_generic(et: e.ElementTree) -> None:
+        pass
+
+    def tree_of_int(et: e.ElementTree[int]) -> None:  # E: Type argument "int" of "_ElementTree" must be a subtype of "_Element"  [type-var]
+        pass
+
+    def get_tree(el: e.Element) -> None:
+        tree = e.ElementTree(el)
+        tree_root(tree)
+
+- case: annaotate_comment_public
+  main: |
+    from lxml import etree as e
+
+    def get_element(el: e.Element) -> None:
+        reveal_type(el.tag)  # NR: .+ "Union\[[\w\.]+\.str, [\w\.]+\.bytes, [\w\.]+\.bytearray, [\w\.]+\.QName\]"
+
+    def get_comment(comm: e._Comment) -> None:
+        reveal_type(comm)  # NR: .+ "[\w\.]+\._Comment"
+        reveal_type(comm.tag)  # NR: .+ "def \(.+\) -> [\w\.]+\._Comment"
+        get_element(comm)
+
+    def check_if_element_is_comment(el: e.Element) -> bool:
+        # The following should not be an error.
+        # It is a valid check that an element is a comment.
+        return el.tag == e.Comment
+
+    comm = e.Comment("comment")
+    print(comm.tag == e.Comment)
+    check_if_element_is_comment(comm)
+
+- case: annaotate_html_public
+  main: |
+    from lxml import etree as e
+    from lxml import html as h
+
+    def element_tree(et: e.ElementTree[e.Element]) -> None:
+        pass
+
+    def html_tree(et: e.ElementTree[h.HtmlElement]) -> None:
+        element_tree(et)
+
+    def element_tree_not_html(et: e.ElementTree[e.Element]) -> None:
         html_tree(et)  # E: Argument 1 to "html_tree" has incompatible type "_ElementTree[_Element]"; expected "_ElementTree[HtmlElement]"  [arg-type]


### PR DESCRIPTION
This PR replaces PR #81 as requested.

Element() and ElementTree() were factory functions until now. They are now defined as classes.

With this change, we can annotate code with the public Element class, instead of using the private _Element class.
For example:
```
def print_tree(tree: e.ElementTree[e.Element]) -> None: ...
```

There is a related PR that was merged into lxml:
https://github.com/lxml/lxml/pull/405

In the lxml PR, _Element is a virtual subclass of Element. This means that when we create an Element it actually creates an _Element class, but the created object is also an instance of Element:
```
el = Element()
reveal_type(el)  # _Element
isinstance(element, Element)  # True
isinstance(element, _Element)  # True
```