### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_inc.yml
+++ b/.github/workflows/test_inc.yml
@@ -1,6 +1,8 @@
 # For inclusion in another workflow only
 
 name: Reusable test workflow
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/abelcheung/types-lxml/security/code-scanning/10](https://github.com/abelcheung/types-lxml/security/code-scanning/10)

In general, the fix is to explicitly set a `permissions` block at the workflow level (applies to all jobs) or per job, restricting the `GITHUB_TOKEN` to the minimal scopes needed. For this workflow, the jobs only need to interact with actions artifacts; they don't push commits or manage issues/PRs. Thus we can safely set `permissions: contents: read` at the workflow root as a conservative baseline (the minimum GitHub recommends for most workflows) while leaving the existing `actions: write` permission on the `log-aggregation` job, which is already explicitly configured for cleaning up artifacts.

The single best fix without changing functionality is:
- Add a workflow-level `permissions` block just after the `name:` line.
- Set `contents: read` there, which is sufficient for typical artifact operations and avoids unnecessary write privileges.
- Keep the existing `permissions` on the `log-aggregation` job as-is, since it explicitly needs `actions: write` for `geekyeggo/delete-artifact@v5`.

All required changes are confined to `.github/workflows/test_inc.yml`, and no imports or additional methods are involved since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
