### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,5 +1,8 @@
 name: Type checker compatibility tests
 
+permissions:
+  contents: read
+
 on:
   - workflow_dispatch
 


### PR DESCRIPTION
Potential fix for [https://github.com/abelcheung/types-lxml/security/code-scanning/9](https://github.com/abelcheung/types-lxml/security/code-scanning/9)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for this workflow. Since all jobs only need to read repository contents (for `actions/checkout`) and do local type checking, we can add a workflow-level `permissions` block with `contents: read`. This will apply to all jobs that don’t override it, satisfying the least-privilege requirement and the CodeQL rule.

The single best fix without changing functionality is:

- In `.github/workflows/compat.yml`, add a top-level `permissions:` section after the `name:` (or before `on:`) with `contents: read`.
- This ensures that all jobs (`mypy_compat`, `pyright_compat`, `basedpyright_compat`, and `pyrefly_compat`) run with a read-only token, which is sufficient for `actions/checkout` and does not affect the existing logic of installing dependencies and running type checkers.

No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
