### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_inc.yml
+++ b/.github/workflows/build_inc.yml
@@ -2,6 +2,9 @@
 
 name: Reusable build workflow
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/abelcheung/types-lxml/security/code-scanning/3](https://github.com/abelcheung/types-lxml/security/code-scanning/3)

To fix the problem, add an explicit `permissions:` block that limits the `GITHUB_TOKEN` to the least privilege needed. This can be done at the workflow root so it applies to all jobs, unless a job overrides it. The steps only need to read the repository (for `actions/checkout`) and interact with artifacts, which do not rely on elevated repo permissions, so `contents: read` is sufficient.

The best minimal fix is to insert a top-level `permissions:` section after the `name:` (or before `on:`) in `.github/workflows/build_inc.yml`:

- At the workflow root (same indentation as `name:` and `on:`), add:
  ```yaml
  permissions:
    contents: read
  ```
- No job-level permissions override is needed since both `build` and `checksrc` only require read access to the repo contents.
- No imports or additional definitions are required; this is a declarative YAML-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
