### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build_inc.yml
     with:
       gitref: ${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/abelcheung/types-lxml/security/code-scanning/7](https://github.com/abelcheung/types-lxml/security/code-scanning/7)

To fix the problem, add an explicit `permissions` block to the `build` job so that the GITHUB_TOKEN is restricted instead of inheriting repository defaults. Since the `build` job only dispatches a reusable workflow and passes `gitref`, it almost certainly needs at most read access to repository contents. A safe, minimal starting point consistent with GitHub’s recommendations is `permissions: contents: read`.

Concretely, in `.github/workflows/release.yml`, under `jobs: build:`, insert a `permissions:` mapping before `uses:`. This will apply only to the `build` job and will not affect the other jobs, which already declare their own permissions. No additional methods, imports, or definitions are needed since this is just a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
